### PR TITLE
Fix/ante atomtyping

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ The `pip install` command should be issued from within the same `conda` environm
 - foyer >= 0.7.2
 - ambertools (for the `antefoyer.ante_atomtyping` and `antefoyer.ante_charges` functions)
 
+Both dependencies can be installed via conda:
+
+	conda install -c omnia -c mosdef -c conda-forge foyer ambertools
+
 ## Usage
 There are two primary workflows for atomtyping with `antefoyer`. The first uses the traditional `foyer` approach with SMARTS strings defined in `antefoyer/xml/gaff.xml`. 
 
@@ -46,14 +50,13 @@ There are two primary workflows for atomtyping with `antefoyer`. The first uses 
     GAFF = foyer.forcefields.load_GAFF()
     
     # Use foyer to parameterize
-    parmaeterized_molecule = GAFF.apply(molecule.to_parmed())
+    parameterized_molecule = GAFF.apply(molecule.to_parmed())
     
     # Save to whatever file format you desire
     
 Note that `antefoyer` was _never_ imported. If `antefoyer` is properly installed, the GAFF forcefield will become available under `foyer.forcefields.load_GAFF()` via `entrypoints`. 
 
-The second workflow uses the antechamber wrapper. This requires `antechamber` to be installed an accesible in your `PATH`. `Antechamber` can be installed from conda: `conda install -c ambermd ambertools`. __THIS WORKFLOW IS UNDER CONSTRUCTION AND NOT FULLY SUPPORTED BY FOYER__.
-
+The second workflow uses the antechamber wrapper. This requires `antechamber` to be installed an accesible in your `PATH`. `Antechamber` can be installed from conda: `conda install -c conda-forge ambertools`.
 
     # Assuming we also have mbuild installed for this example
     import foyer
@@ -63,16 +66,16 @@ The second workflow uses the antechamber wrapper. This requires `antechamber` to
     import antefoyer
     
     # Build/import a molecule
-    molecule = mb.load('CCC',smarts=True)
+    molecule = mb.load('CCC', smiles=True)
     
     # Load GAFF
-    GAFF = foyer.forcefields.load_GAFF()
+    gaff = foyer.forcefields.load_GAFF()
     
     # Identify GAFF atomtypes with antechamber
-    typed_molecule = antefoyer.ante_atomtyping(molecule,'gaff')
+    typed_molecule = antefoyer.ante_atomtyping(molecule, 'gaff')
     
     # Use foyer to parameterize
-    parmaeterized_molecule = GAFF.apply(typed_molecule, run_atomtyping=False)
+    parameterized_molecule = gaff.parametrize_system(typed_molecule)
     
     # We can also apply AM1-BCC charges from antechamber
     molecule_with_charges = antefoyer.ante_charges(parameterized_molecule,'bcc')

--- a/antefoyer/antefoyer.py
+++ b/antefoyer/antefoyer.py
@@ -5,7 +5,6 @@ import sys
 import warnings
 
 import parmed as pmd
-import networkx as nx
 
 from distutils.spawn import find_executable
 from subprocess import PIPE, Popen

--- a/antefoyer/antefoyer.py
+++ b/antefoyer/antefoyer.py
@@ -72,6 +72,10 @@ def ante_atomtyping(molecule, atype_style):
             # Now read in the mol2 file with atomtyping
             typed_molecule = pmd.load_file('ante_out.mol2',structure=True)
 
+    # Foyer requires that the atom type info is stored under atom.id
+    for atom in typed_molecule:
+        atom.id = atom.type
+
     # And return it
     return typed_molecule
 


### PR DESCRIPTION
## Description

Update the behavior of `ante_atomtyping` to work properly with the current version of `foyer`. Also update README to correctly describe the `parametrize_system` step. 