### PR TITLE
Charge redistribution

### DIFF
--- a/antefoyer/antefoyer.py
+++ b/antefoyer/antefoyer.py
@@ -160,7 +160,7 @@ def ante_charges(
             charges = pmd.load_file("ante_out.mol2", structure=True)
 
             charge_list = [atom.charge for atom in charges]
-            if (net_charge - sum(charge_list)) > charge_tol:
+            if abs(net_charge - sum(charge_list)) > charge_tol:
                 raise ValueError(
                     "The sum of charges defined by antechamber"
                     " is {}, which differs from the desired net charge"
@@ -168,7 +168,7 @@ def ante_charges(
                         sum(charge_list), net_charge, charge_tol
                     )
                 )
-            elif (net_charge - sum(charge_list)) < charge_tol:
+            elif abs(net_charge - sum(charge_list)) < charge_tol:
                 charge_delta = (net_charge - sum(charge_list)) / len(charge_list)
                 for atom in charges:
                     atom.charge += charge_delta

--- a/antefoyer/antefoyer.py
+++ b/antefoyer/antefoyer.py
@@ -15,7 +15,8 @@ from antefoyer.utils.tempdir import temporary_cd
 from foyer.exceptions import FoyerError
 from foyer.utils.io import import_, has_mbuild
 
-ANTECHAMBER = find_executable('antechamber')
+ANTECHAMBER = find_executable("antechamber")
+
 
 def ante_atomtyping(molecule, atype_style):
     """Perform atomtyping by calling antechamber
@@ -36,10 +37,12 @@ def ante_atomtyping(molecule, atype_style):
     _check_antechamber(ANTECHAMBER)
 
     # Check valid atomtype name
-    supported_atomtypes = ['gaff', 'gaff2', 'amber', 'bcc', 'sybyl' ]
+    supported_atomtypes = ["gaff", "gaff2", "amber", "bcc", "sybyl"]
     if atype_style not in supported_atomtypes:
-        raise FoyerError( 'Unsupported atomtyping style requested. '
-            'Please select from {}'.format(supported_atomtypes))
+        raise FoyerError(
+            "Unsupported atomtyping style requested. "
+            "Please select from {}".format(supported_atomtypes)
+        )
 
     # Check for parmed.Structure. Convert from mbuild.Compound if possible
     molecule = _check_structure(molecule)
@@ -53,24 +56,25 @@ def ante_atomtyping(molecule, atype_style):
     with temporary_directory() as tmpdir:
         with temporary_cd(tmpdir):
             # Save the existing molecule to file
-            _write_pdb(molecule,'ante_in.pdb')
+            _write_pdb(molecule, "ante_in.pdb")
             # Call antechamber
-            command = ( 'antechamber -i ante_in.pdb -fi pdb '
-                         '-o ante_out.mol2 -fo mol2 ' +
-                         '-at ' + atype_style + ' ' +
-                         '-s 2' )
+            command = (
+                "antechamber -i ante_in.pdb -fi pdb "
+                "-o ante_out.mol2 -fo mol2 " + "-at " + atype_style + " " + "-s 2"
+            )
 
-            proc = Popen(command, stdout=PIPE, stderr=PIPE,
-                         universal_newlines=True, shell=True)
+            proc = Popen(
+                command, stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True
+            )
 
             out, err = proc.communicate()
 
             # Error handling here
-            if 'Fatal Error' in err or proc.returncode != 0:
-                _antechamber_error(out,err,workdir)
+            if "Fatal Error" in err or proc.returncode != 0:
+                _antechamber_error(out, err, workdir)
 
             # Now read in the mol2 file with atomtyping
-            typed_molecule = pmd.load_file('ante_out.mol2',structure=True)
+            typed_molecule = pmd.load_file("ante_out.mol2", structure=True)
 
     # Foyer requires that the atom type info is stored under atom.id
     for atom in typed_molecule:
@@ -79,8 +83,10 @@ def ante_atomtyping(molecule, atype_style):
     # And return it
     return typed_molecule
 
-def ante_charges(molecule, charge_style, net_charge=0.0,
-                           multiplicity=1):
+
+def ante_charges(
+    molecule, charge_style, net_charge=0.0, multiplicity=1, charge_tol=0.005
+):
     """Calculates partial charges by calling antechamber
 
     Parameters
@@ -104,10 +110,12 @@ def ante_charges(molecule, charge_style, net_charge=0.0,
     _check_antechamber(ANTECHAMBER)
 
     # Check valid atomtype name
-    supported_chargetypes = ['bcc', 'gas', 'mul']
+    supported_chargetypes = ["bcc", "gas", "mul"]
     if charge_style not in supported_chargetypes:
-        raise FoyerError( 'Unsupported charge style requested. '
-            'Please select from {}'.format(supported_chargetypes))
+        raise FoyerError(
+            "Unsupported charge style requested. "
+            "Please select from {}".format(supported_chargetypes)
+        )
 
     # Check for parmed.Structure. Convert from mbuild.Compound if possible
     molecule = _check_structure(molecule)
@@ -121,46 +129,69 @@ def ante_charges(molecule, charge_style, net_charge=0.0,
     with temporary_directory() as tmpdir:
         with temporary_cd(tmpdir):
             # Save the existing molecule to file
-            _write_pdb(molecule,'ante_in.pdb')
+            _write_pdb(molecule, "ante_in.pdb")
             # Call antechamber
-            command = ( 'antechamber -i ante_in.pdb -fi pdb '
-                         '-o ante_out.mol2 -fo mol2 ' +
-                         '-c ' + charge_style + ' ' +
-                         '-nc ' + str(net_charge) + ' ' +
-                         '-m ' + str(multiplicity) +  ' ' +
-                         '-s 2' )
+            command = (
+                "antechamber -i ante_in.pdb -fi pdb "
+                "-o ante_out.mol2 -fo mol2 "
+                + "-c "
+                + charge_style
+                + " "
+                + "-nc "
+                + str(net_charge)
+                + " "
+                + "-m "
+                + str(multiplicity)
+                + " "
+                + "-s 2"
+            )
 
-            proc = Popen(command, stdout=PIPE, stderr=PIPE,
-                         universal_newlines=True, shell=True)
+            proc = Popen(
+                command, stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True
+            )
 
             out, err = proc.communicate()
 
             # Error handling here
-            if 'Fatal Error' in err or proc.returncode != 0:
-                _antechamber_error(out,err,workdir)
+            if "Fatal Error" in err or proc.returncode != 0:
+                _antechamber_error(out, err, workdir)
 
             # Now read in the mol2 file with atomtyping
-            charges = pmd.load_file('ante_out.mol2',structure=True)
+            charges = pmd.load_file("ante_out.mol2", structure=True)
+
+            charge_list = [atom.charge for atom in charges]
+            if (net_charge - sum(charge_list)) > charge_tol:
+                raise ValueError(
+                    "The sum of charges defined by antechamber"
+                    " is {}, which differs from the desired net charge"
+                    " of {} by a value greater than {}".format(
+                        sum(charge_list), net_charge, charge_tol
+                    )
+                )
+            elif (net_charge - sum(charge_list)) < charge_tol:
+                charge_delta = (net_charge - sum(charge_list)) / len(charge_list)
+                for atom in charges:
+                    atom.charge += charge_delta
 
     # Combine charge information with existing molecule structure
     assert len(molecule.atoms) == len(charges.atoms)
     for atom_idx in range(len(molecule.atoms)):
-        assert molecule.atoms[atom_idx].element == \
-                charges.atoms[atom_idx].element
+        assert molecule.atoms[atom_idx].element == charges.atoms[atom_idx].element
         molecule.atoms[atom_idx].charge = charges.atoms[atom_idx].charge
     return molecule
 
-def _write_pdb(molecule,filename):
+
+def _write_pdb(molecule, filename):
     """Write a pdb file with CONECT records."""
 
     # Check that we have a box. If not, define one.
     if molecule.box is None:
-        molecule.box = [10.,10.,10.,90.,90.,90.]
+        molecule.box = [10.0, 10.0, 10.0, 90.0, 90.0, 90.0]
 
     assert len(molecule.box) == 6, "Invalid box object."
 
     # Generate CONECT records
-    conect = { atom.idx : [] for atom in molecule.atoms }
+    conect = {atom.idx: [] for atom in molecule.atoms}
     for atom in molecule.atoms:
         atidx = atom.idx
         for bond in molecule.bonds:
@@ -169,40 +200,63 @@ def _write_pdb(molecule,filename):
             elif bond.atom2.idx == atidx:
                 conect[atidx].append(bond.atom1.idx)
 
-    with open(filename, 'w') as pdb:
-        pdb.write('REMARK 1   Created by antefoyer\n')
-        pdb.write('CRYST1{:9.3f}{:9.3f}{:9.3f}{:7.2f}{:7.2f}{:7.2f}'
-                  ' {:9s}{:3d}\n'.format(molecule.box[0],molecule.box[1],
-                      molecule.box[2],molecule.box[3],molecule.box[4],
-                      molecule.box[5],molecule.space_group,1))
+    with open(filename, "w") as pdb:
+        pdb.write("REMARK 1   Created by antefoyer\n")
+        pdb.write(
+            "CRYST1{:9.3f}{:9.3f}{:9.3f}{:7.2f}{:7.2f}{:7.2f}"
+            " {:9s}{:3d}\n".format(
+                molecule.box[0],
+                molecule.box[1],
+                molecule.box[2],
+                molecule.box[3],
+                molecule.box[4],
+                molecule.box[5],
+                molecule.space_group,
+                1,
+            )
+        )
         for atom in molecule.atoms:
-            pdb.write('ATOM  {:5d} {:4s} RES A{:4d}    '
-                    '{:8.3f}{:8.3f}{:8.3f}{:6.2f}{:6.2f}'
-                    '          {:>2s}  \n'.format(atom.idx+1,atom.name,
-                        0,atom.xx,atom.xy,atom.xz,1.0,0.0,
-                        atom.element_name))
+            pdb.write(
+                "ATOM  {:5d} {:4s} RES A{:4d}    "
+                "{:8.3f}{:8.3f}{:8.3f}{:6.2f}{:6.2f}"
+                "          {:>2s}  \n".format(
+                    atom.idx + 1,
+                    atom.name,
+                    0,
+                    atom.xx,
+                    atom.xy,
+                    atom.xz,
+                    1.0,
+                    0.0,
+                    atom.element_name,
+                )
+            )
         for atidx, atomlist in conect.items():
-            pdb.write('CONECT{:5d}'.format(atidx+1))
+            pdb.write("CONECT{:5d}".format(atidx + 1))
             for at2idx in atomlist:
-                pdb.write('{:5d}'.format(at2idx+1))
-            pdb.write('\n')
+                pdb.write("{:5d}".format(at2idx + 1))
+            pdb.write("\n")
+
 
 def _check_structure(molecule):
     """ Confirm that input is parmed.Structure. Convert
     from mbuild.Compound to parmed.Structure if possible.
     """
     if not isinstance(molecule, pmd.Structure) and has_mbuild:
-        mb = import_('mbuild')
+        mb = import_("mbuild")
         if isinstance(molecule, mb.Compound):
             molecule = molecule.to_parmed()
 
     if not isinstance(molecule, pmd.Structure):
-        raise FoyerError('Unknown molecule format: {}\n'
-                         'Supported formats are: '
-                         '"parmed.Structure" and '
-                         '"mbuild.Compound"'.format(molecule))
+        raise FoyerError(
+            "Unknown molecule format: {}\n"
+            "Supported formats are: "
+            '"parmed.Structure" and '
+            '"mbuild.Compound"'.format(molecule)
+        )
 
     return molecule
+
 
 def _check_single_molecule(molecule):
     """ Confirms that the parmed structure represents a single
@@ -213,28 +267,33 @@ def _check_single_molecule(molecule):
     for atom in molecule.atoms:
         graph_nodes.append(atom.idx)
     for bond in molecule.bonds:
-        graph_edges.append([bond.atom1.idx,bond.atom2.idx])
+        graph_edges.append([bond.atom1.idx, bond.atom2.idx])
     bond_graph = nx.Graph()
     bond_graph.add_edges_from(graph_edges)
     bond_graph.add_nodes_from(graph_nodes)
     if not nx.is_connected(bond_graph):
-        raise FoyerError("Antechamber requires connectivity information and "
-                         "only supports single molecules (i.e., all atoms "
-                         "in the molecule are connected by bonds.")
+        raise FoyerError(
+            "Antechamber requires connectivity information and "
+            "only supports single molecules (i.e., all atoms "
+            "in the molecule are connected by bonds."
+        )
+
 
 def _antechamber_error(out, err, workdir):
     """Log antechamber output to file. """
-    with open(workdir+'/ante_errorlog.txt', 'w') as log_file:
+    with open(workdir + "/ante_errorlog.txt", "w") as log_file:
         log_file.write("STDOUT:\n\n")
         log_file.write(out)
         log_file.write("STDERR:\n\n")
         log_file.write(err)
     raise RuntimeError("Antechamber failed. See 'ante_errorlog.txt'")
 
+
 def _check_antechamber(ANTECHAMBER):
     if not ANTECHAMBER:
-        msg = ("Antechamber not found. Please ensure that antechamber "
-               "is available. It can be installed via conda, "
-               "'conda install -c conda-forge ambertools'")
+        msg = (
+            "Antechamber not found. Please ensure that antechamber "
+            "is available. It can be installed via conda, "
+            "'conda install -c conda-forge ambertools'"
+        )
         raise IOError(msg)
-

--- a/antefoyer/tests/test_antefoyer.py
+++ b/antefoyer/tests/test_antefoyer.py
@@ -4,6 +4,7 @@ Unit and regression test for the antefoyer package.
 
 import pytest
 import parmed as pmd
+import numpy as np
 
 from antefoyer.antefoyer import *
 
@@ -17,65 +18,88 @@ from antefoyer.utils.tempdir import temporary_cd
 from distutils.spawn import find_executable
 from os.path import isfile
 
-ANTECHAMBER = find_executable('antechamber')
+ANTECHAMBER = find_executable("antechamber")
+
 
 @pytest.mark.skipif(ANTECHAMBER is not None, reason="antechamber is installed")
 def test_check_antechamber():
-    ethane = pmd.load_file(get_fn('ethane.mol2'),structure=True)
+    ethane = pmd.load_file(get_fn("ethane.mol2"), structure=True)
     with pytest.raises(IOError):
-        typed = ante_atomtyping(ethane,'gaff')
+        typed = ante_atomtyping(ethane, "gaff")
+
 
 # TODO: Break this into mult. functions and check atypes
 @pytest.mark.skipif(ANTECHAMBER is None, reason="antechamber is not installed")
 def test_valid_atype_style():
-    ethane = pmd.load_file(get_fn('ethane.mol2'),structure=True)
-    typed = ante_atomtyping(ethane,'gaff')
-    typed = ante_atomtyping(ethane,'gaff2')
-    typed = ante_atomtyping(ethane,'amber')
-    typed = ante_atomtyping(ethane,'bcc')
-    typed = ante_atomtyping(ethane,'sybyl')
+    ethane = pmd.load_file(get_fn("ethane.mol2"), structure=True)
+    typed = ante_atomtyping(ethane, "gaff")
+    typed = ante_atomtyping(ethane, "gaff2")
+    typed = ante_atomtyping(ethane, "amber")
+    typed = ante_atomtyping(ethane, "bcc")
+    typed = ante_atomtyping(ethane, "sybyl")
+
 
 @pytest.mark.skipif(ANTECHAMBER is None, reason="antechamber is not installed")
 def test_invalid_atype_style():
-    ethane = pmd.load_file(get_fn('ethane.mol2'),structure=True)
-    with pytest.raises(FoyerError,match=r"Unsupported atomtyping style.*"):
-        typed = ante_atomtyping(ethane,'gaffff')
+    ethane = pmd.load_file(get_fn("ethane.mol2"), structure=True)
+    with pytest.raises(FoyerError, match=r"Unsupported atomtyping style.*"):
+        typed = ante_atomtyping(ethane, "gaffff")
+
 
 @pytest.mark.skipif(ANTECHAMBER is None, reason="antechamber is not installed")
 def test_ethane_gaff_atypes():
-    ethane = pmd.load_file(get_fn('ethane.mol2'),structure=True)
-    typed = ante_atomtyping(ethane,'gaff')
-    assert sum((1 for at in typed.atoms if at.type == 'c3')) == 2
-    assert sum((1 for at in typed.atoms if at.type == 'hc')) == 6
+    ethane = pmd.load_file(get_fn("ethane.mol2"), structure=True)
+    typed = ante_atomtyping(ethane, "gaff")
+    assert sum((1 for at in typed.atoms if at.type == "c3")) == 2
+    assert sum((1 for at in typed.atoms if at.type == "hc")) == 6
+
 
 @pytest.mark.skipif(ANTECHAMBER is None, reason="antechamber is not installed")
 def test_invalid_structure():
-    ethane = pmd.load_file(get_fn('ethane.mol2'),structure=True)
-    with pytest.raises(FoyerError,match=r"Unknown molecule format.*"):
-        typed = ante_atomtyping(ethane.topology,'gaff')
+    ethane = pmd.load_file(get_fn("ethane.mol2"), structure=True)
+    with pytest.raises(FoyerError, match=r"Unknown molecule format.*"):
+        typed = ante_atomtyping(ethane.topology, "gaff")
+
 
 @pytest.mark.skipif(ANTECHAMBER is None, reason="antechamber is not installed")
 @pytest.mark.skipif(not has_mbuild, reason="mbuild is not installed")
 def test_convert_mbuild():
     import mbuild as mb
-    ethane = mb.load(get_fn('ethane.mol2'))
-    typed = ante_atomtyping(ethane,'gaff')
+
+    ethane = mb.load(get_fn("ethane.mol2"))
+    typed = ante_atomtyping(ethane, "gaff")
+
 
 @pytest.mark.skipif(ANTECHAMBER is None, reason="antechamber is not installed")
 def test_multiple_molecules():
-    ethane = pmd.load_file(get_fn('ethane.mol2'),structure=True)
+    ethane = pmd.load_file(get_fn("ethane.mol2"), structure=True)
     # Remove a bond to break the molecule apart
     ethane.bonds.remove(ethane.bonds[0])
-    with pytest.raises(FoyerError,match=r"Antechamber requires connectivity.*"):
-        typed = ante_atomtyping(ethane,'gaff')
+    with pytest.raises(FoyerError, match=r"Antechamber requires connectivity.*"):
+        typed = ante_atomtyping(ethane, "gaff")
 
-# TODO: Write this test. What to do about error logfile handling? 
+
+# TODO: Write this test. What to do about error logfile handling?
 @pytest.mark.skipif(ANTECHAMBER is None, reason="antechamber is not installed")
 def test_ante_error():
-    ethane = pmd.load_file(get_fn('ethane.mol2'),structure=True)
+    ethane = pmd.load_file(get_fn("ethane.mol2"), structure=True)
     with temporary_directory() as tmpdir:
         with temporary_cd(tmpdir):
-            with pytest.raises(RuntimeError,match=r"Antechamber failed"):
-                charges = ante_charges(ethane,'bcc',net_charge=-1)
-            assert isfile('ante_errorlog.txt')
+            with pytest.raises(RuntimeError, match=r"Antechamber failed"):
+                charges = ante_charges(ethane, "bcc", net_charge=-1)
+            assert isfile("ante_errorlog.txt")
 
+
+@pytest.mark.skipif(ANTECHAMBER is None, reason="antechamber is not installed")
+def test_ante_charge_delta():
+    ethane = pmd.load_file(get_fn("ethane.mol2"), structure=True)
+    charges = ante_charges(ethane, "bcc", net_charge=0)
+
+    assert np.allclose(sum([i.charge for i in charges]), 0, atol=5e-3)
+
+
+@pytest.mark.skipif(ANTECHAMBER is None, reason="antechamber is not installed")
+def test_charge_tolerance():
+    with pytest.raises(ValueError, match=r"The sum of charges"):
+        ethane = pmd.load_file(get_fn("ethane.mol2"), structure=True)
+        ante_charges(ethane, "bcc", charge_tol=0.001)

--- a/antefoyer/tests/test_antefoyer.py
+++ b/antefoyer/tests/test_antefoyer.py
@@ -95,7 +95,7 @@ def test_ante_charge_delta():
     ethane = pmd.load_file(get_fn("ethane.mol2"), structure=True)
     charges = ante_charges(ethane, "bcc", net_charge=0)
 
-    assert np.allclose(sum([i.charge for i in charges]), 0, atol=5e-3)
+    assert np.allclose(sum([i.charge for i in charges]), 0)
 
 
 @pytest.mark.skipif(ANTECHAMBER is None, reason="antechamber is not installed")


### PR DESCRIPTION
## Description
Addressing issue discussed in #13.  I added the argument `charge_tol` to `ante_charges`.  If the absolute value of the `net_charge` minus the charges assigned by antechamber is greater than `charge_tol`, then an error will be raised.  If the absolute value is less than `charge_tol` but greater than zero, the net charge will be evenly distributed across all atoms of the molecule.

Currently `charge_tol` is set to 5e-3, but I would be open to changing this.  I also added tests to check that 1) charges get redistributed correctly and 2) an error gets raised if abs(net_charge - antechamber charges) > `charge_tol`.

I also ran black on the files I edited which is why a lot of lines got reformatted.


## Questions
- [ ] Question1

## Status
- [x] Ready to go